### PR TITLE
Add documentation around the Config options available

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,63 @@ Mjolnir is designed to be agnostic to issues and the solutions to them; however,
 
 After a new problem has been identified, it should be fairly trivial to create a new plugin to solve the problem, and add it to the configured pipelines, allowing the administrators to solve a problem once, and then let Mjolnir solve it any time it happens in the future!
 
-## Specifying the plugin pipeline
-Pipelines are specified in the controllers configuration file using toml syntax.  Triggers are matched up against
-actions.  Multiple actions can be specified and they will be tried in order until one succeeds.  
+## Getting Started
+
+A useful starting point for setting up Mjolnir may be:
+
+```toml
+[mjolnir]
+  # key_path is where Mjolnir will store the secret keys used to encrypt
+  # and authenticate communication after the initial handshake has completed
+  key_path = "/usr/local/share/mjolnir"
+  # Masters should reference all master nodes configured to run mjolnird
+  # in master mode
+  masters = ["$MASTER_IP:11011:12011"]
+  # plugin_path is the path on the master node(s) that plugins arelocated at
+  plugin_path = "/build/target/debug/examples"
+  # secret is a shared secret that is used to authenticate communication.
+  #
+  # YOU SHOULD CHANGE THIS
+  #
+  secret = "w[4957ha[ruognqp357gf;eruigap47gfa;IRYEgf0a864fo"
+
+# default_remediation allows Mjolnir to fall back to this remediation if
+# no other configured remediation has resolved an alert. This should be
+# configured to match any existing notification tools (eg: slack, email)
+[mjolnir.default_remediation]
+  plugin = "slack"
+  args = ["botname=user", "channel=#general", "webhook=https://PATH"]
+
+[master]
+bind = "0.0.0.0:11011:12011"
+
+[agent]
+bind = "0.0.0.0:11012:12012"
+
+[[pipelines]]
+
+  # pipelines.actions is an array of actions that will be attempted,
+  # in order, to try to remediate this alert.
+  [[pipelines.actions]]
+    plugin = "clean_disk"
+    # args is an optional configuration option for a remediation that can be
+    # taken. They will be passed into the plugin on call so you should check
+    # the documentation of the configured plugin to see what options it expects
+    args = ["path=/var/log"]
+
+  # pipelines.trigger is the event that will trigger the above configured
+  # actions.
+  [pipelines.trigger]
+    type = "alertmanager"
+    name = "full-disk"
 ```
+
+## Specifying the plugin pipeline
+
+Pipelines are specified in the controllers configuration file using toml syntax.  Triggers are matched up against
+actions.  Multiple actions can be specified and they will be tried in order until one succeeds.
+
+```toml
 [[pipelines]]
   [[pipelines.actions]]
     plugin = "clean_disk"

--- a/mjolnir-api/Cargo.toml
+++ b/mjolnir-api/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Chris MacNaughton <chris@centaurisolutions.nl>",
     "Chris Holcombe <xfactor973@gmail.com>",
 ]
-license = "AGPL-3.0"
+license = "MIT/Apache-2.0"
 build = "build.rs"
 edition = '2018'
 

--- a/mjolnird/Cargo.toml
+++ b/mjolnird/Cargo.toml
@@ -3,6 +3,7 @@ name = "mjolnird"
 version = "0.2.0"
 authors = ["Chris MacNaughton <chris@centaurisolutions.nl>"]
 edition = '2018'
+license = "MIT/Apache-2.0"
 
 [dependencies]
 mjolnir-api = { path = "../mjolnir-api" }

--- a/mjolnird/src/lib.rs
+++ b/mjolnird/src/lib.rs
@@ -1,0 +1,24 @@
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate log;
+
+#[macro_use]
+extern crate serde_derive;
+// workspace members
+
+
+
+mod config;
+pub mod server;
+
+pub use config::{Config, Mode, CliMode};
+
+pub fn cli(config: &Config, mode: CliMode) {
+    info!("Running {:?}", mode);
+    for master in config.masters.iter() {
+        if let Some(key) = server::get_master_pubkey(&master) {
+            server::reload(&master, &key);
+        }
+    }
+}

--- a/mjolnird/src/main.rs
+++ b/mjolnird/src/main.rs
@@ -1,19 +1,9 @@
 #[macro_use]
-extern crate clap;
-#[macro_use]
 extern crate log;
-
-#[macro_use]
-extern crate serde_derive;
 use simple_logger;
-// workspace members
 
 
-
-mod config;
-mod server;
-
-use crate::config::{Config, Mode, CliMode};
+use mjolnird::{Config, Mode, cli, server};
 
 fn main() {
     println!("Welcome to Mjölnir");
@@ -29,13 +19,4 @@ fn main() {
         _ => {}
     }
     server::bind(config).expect("Couldn't bind to the specified port");
-}
-
-fn cli(config: &Config, mode: CliMode) {
-    info!("Running {:?}", mode);
-    for master in config.masters.iter() {
-        if let Some(key) = server::get_master_pubkey(&master) {
-            server::reload(&master, &key);
-        }
-    }
 }

--- a/mjolnird/src/server/agent.rs
+++ b/mjolnird/src/server/agent.rs
@@ -214,7 +214,6 @@ impl Agent {
     }
 }
 
-
 fn remediate(
     remediation: Remediation,
     config: &Config,


### PR DESCRIPTION
This includes a doc test that takes a toml document and runs
it through the config parser to ensure we do not regress config parsing.

Closes #81